### PR TITLE
Set status code to 401

### DIFF
--- a/src/EventSubscriber/AuthenticateSubscriber.php
+++ b/src/EventSubscriber/AuthenticateSubscriber.php
@@ -7,6 +7,7 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\FrontendIndex;
 use Contao\PageModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -48,7 +49,9 @@ class AuthenticateSubscriber implements EventSubscriberInterface
         }
 
         $request->attributes->set(self::REQUEST_ATTRIBUTE, $pageModel->id);
-        $event->setResponse((new FrontendIndex())->renderPage($passwordPageModel));
+        $response = (new FrontendIndex())->renderPage($passwordPageModel);
+        $response->setStatusCode(Response::HTTP_UNAUTHORIZED);
+        $event->setResponse($response);
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
The status code should be set to 401 if the password page is rendered (i.e. if you requested a protected page and you are not authorised to view it yet).

This will also signal to any crawlers that the contents of this page should not be indexed, regardless of any robots settings.