### PR TITLE
Fix `NoLayoutSpecifiedException`

### DIFF
--- a/src/EventSubscriber/AuthenticateSubscriber.php
+++ b/src/EventSubscriber/AuthenticateSubscriber.php
@@ -44,7 +44,7 @@ class AuthenticateSubscriber implements EventSubscriberInterface
         }
 
         // The password page does not exist
-        if (!$pageModel->passwordPage || ($passwordPageModel = PageModel::findPublishedById($pageModel->passwordPage)) === null) {
+        if (!$pageModel->passwordPage || ($passwordPageModel = PageModel::findWithDetails($pageModel->passwordPage)) === null) {
             throw new AccessDeniedException();
         }
 


### PR DESCRIPTION
This PR fixes the following error:

```
Contao\CoreBundle\Exception\NoLayoutSpecifiedException:

  at vendor\contao\core-bundle\src\Controller\Page\AbstractPageController.php:47
  at Contao\CoreBundle\Controller\Page\AbstractPageController->renderPage(object(PageModel))
     (vendor\contao\core-bundle\src\Controller\Page\RegularPageController.php:27)
  at Contao\CoreBundle\Controller\Page\RegularPageController->__invoke(object(PageModel))
     (vendor\contao\core-bundle\contao\controllers\FrontendIndex.php:39)
  at Contao\FrontendIndex->renderPage(object(PageModel))
     (vendor\codefog\contao-page-password\src\EventSubscriber\AuthenticateSubscriber.php:52)
  at Codefog\PagePasswordBundle\EventSubscriber\AuthenticateSubscriber->onKernelRequest(object(RequestEvent), 'kernel.request', object(TraceableEventDispatcher))
     (vendor\symfony\event-dispatcher\Debug\WrappedListener.php:115)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(object(RequestEvent), 'kernel.request', object(TraceableEventDispatcher))
     (vendor\symfony\event-dispatcher\EventDispatcher.php:206)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners(array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'kernel.request', object(RequestEvent))
     (vendor\symfony\event-dispatcher\EventDispatcher.php:56)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch(object(RequestEvent), 'kernel.request')
     (vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php:129)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(object(RequestEvent), 'kernel.request')
     (vendor\symfony\http-kernel\HttpKernel.php:159)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:42)
```

This happens because the layout is only inherited when `->loadDetails()` is executed on the page model.