### PR TITLE
Fix ChangeLanguage menu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "contao/manager-plugin": "^2.0"
     },
     "conflict": {
-        "contao/manager-plugin": "<2.0 || >=3.0"
+        "contao/manager-plugin": "<2.0 || >=3.0",
+        "terminal42/contao-changelanguage": "<3.0 || >=4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/EventListener/ChangeLanguageNavigationListener.php
+++ b/src/EventListener/ChangeLanguageNavigationListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Codefog\PagePasswordBundle\EventListener;
+
+use Codefog\PagePasswordBundle\EventSubscriber\AuthenticateSubscriber;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
+use Contao\PageModel;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Terminal42\ChangeLanguage\Event\ChangelanguageNavigationEvent;
+use Terminal42\ChangeLanguage\PageFinder;
+
+#[AsHook('changelanguageNavigation')]
+class ChangeLanguageNavigationListener
+{
+    public function __construct(
+        private readonly PageFinder $pageFinder,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function __invoke(ChangelanguageNavigationEvent $event): void
+    {
+        if (!$request = $this->requestStack->getMainRequest()) {
+            return;
+        }
+
+        if (!$request->attributes->has(AuthenticateSubscriber::REQUEST_ATTRIBUTE)) {
+            return;
+        }
+
+        if (!$sourcePage = PageModel::findById($request->attributes->get(AuthenticateSubscriber::REQUEST_ATTRIBUTE))) {
+            return;
+        }
+
+        $item = $event->getNavigationItem();
+
+        if (!$targetPage = $this->pageFinder->findAssociatedForLanguage($sourcePage, $item->getRootPage()->rootLanguage)) {
+            $targetPage = $sourcePage;
+        }
+
+        $item->setTargetPage($targetPage, $item->isDirectFallback(), str_starts_with($request->getUri(), $targetPage->getAbsoluteUrl()));
+    }
+}

--- a/src/EventListener/ChangeLanguageNavigationListener.php
+++ b/src/EventListener/ChangeLanguageNavigationListener.php
@@ -28,7 +28,7 @@ class ChangeLanguageNavigationListener
             return;
         }
 
-        if (!$sourcePage = PageModel::findById($request->attributes->get(AuthenticateSubscriber::REQUEST_ATTRIBUTE))) {
+        if (!$sourcePage = PageModel::findPublishedById($request->attributes->get(AuthenticateSubscriber::REQUEST_ATTRIBUTE))) {
             return;
         }
 


### PR DESCRIPTION
Since the `AuthenticateSubscriber` renders the selected password page, the "Change Language" menu of the ChangeLanguage extension will also have generated links for the password pages - instead of the current page.

This PR fixes that by restoring the URLs to the original source page via the `changelanguageNavigation` hook.